### PR TITLE
Add submission template and stage for Gleam Chess Tournament

### DIFF
--- a/compiled_starters/gleam/example.ENTRY.md
+++ b/compiled_starters/gleam/example.ENTRY.md
@@ -1,0 +1,16 @@
+# Gleam Chess Tournament Submission
+
+## Participant Information
+
+- Email: [Your Email]
+- Name: [Your Name]
+
+### Git Repository URL
+
+- Repository URL: [Your Repo URL] (Should be a public repo with the code for the
+  bot.)
+
+---
+
+_Note: Your name may be used in the video/stream at the end of the tournament,
+so provide something you're happy sharing with the world._

--- a/course-definition.yml
+++ b/course-definition.yml
@@ -193,3 +193,23 @@ stages:
       - Your bot must make moves within the 5 second time limit
     marketing_md: |-
       Create a complete chess engine that can play and win full games.
+  
+  - slug: "gd8"
+    name: "Submit your bot"
+    difficulty: easy
+    description_md: |-
+      In this stage, you'll finalize your submission for the tournament.
+      There is an `example.ENTRY.md` file in the starter code that was provided. You will need to rename the file to `ENTRY.md` and fill in the required fields. 
+      You need to mention your name, email and the URL to your repository.
+      If you don't intend to participate in the tournament, you don't need to fill the details.
+
+      ### Tests
+
+      The tester will test for the presence of the `ENTRY.md` file in your repository.
+
+      ### Notes
+
+      - Please do not remove the `example.ENTRY.md` file, before you are ready to submit.
+    marketing_md: |-
+      Submit your bot to the tournament.
+  

--- a/solutions/gleam/01-si0/code/example.ENTRY.md
+++ b/solutions/gleam/01-si0/code/example.ENTRY.md
@@ -1,0 +1,16 @@
+# Gleam Chess Tournament Submission
+
+## Participant Information
+
+- Email: [Your Email]
+- Name: [Your Name]
+
+### Git Repository URL
+
+- Repository URL: [Your Repo URL] (Should be a public repo with the code for the
+  bot.)
+
+---
+
+_Note: Your name may be used in the video/stream at the end of the tournament,
+so provide something you're happy sharing with the world._

--- a/starter_templates/all/code/example.ENTRY.md
+++ b/starter_templates/all/code/example.ENTRY.md
@@ -1,0 +1,13 @@
+# Gleam Chess Tournament Submission
+
+## Participant Information
+- Email: [Your Email]
+- Name: [Your Name]
+
+### Git Repository URL
+- Repository URL: [Your Repo URL]
+(Should be a public repo with the code for the bot.)
+
+---
+
+*Note: Your name may be used in the video/stream at the end of the tournament, so provide something you're happy sharing with the world.*


### PR DESCRIPTION
Introduce a template for tournament submissions and define a submission stage in the course structure. This enhances participant guidance and streamlines the submission process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a submission template for the Gleam Chess Tournament, allowing participants to provide their name, email, and bot repository URL.
	- Added a new course stage guiding users to complete and submit their tournament entry using the provided template.

- **Documentation**
	- Added clear instructions and notes to the submission template, including guidance on public sharing of participant names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->